### PR TITLE
Fix docopt syntax

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "constellation-rs"
-version = "0.1.8"
+version = "0.1.9"
 license = "Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","network-programming","concurrency","asynchronous","command-line-utilities"]
@@ -12,7 +12,7 @@ Constellation is a framework for Rust (nightly) that aides in the writing, debug
 """
 repository = "https://github.com/alecmocatta/constellation"
 homepage = "https://github.com/alecmocatta/constellation"
-documentation = "https://docs.rs/constellation-rs/0.1.8"
+documentation = "https://docs.rs/constellation-rs/0.1.9"
 readme = "README.md"
 links = "constellation"
 build = "build.rs"
@@ -32,7 +32,7 @@ no_alloc = ["constellation-internal/no_alloc"]
 kubernetes = ["distribute_binaries", "k8s-openapi", "kube", "openssl", "tokio"]
 
 [dependencies]
-constellation-internal = { path = "constellation-internal", version = "=0.1.8" }
+constellation-internal = { path = "constellation-internal", version = "=0.1.9" }
 atty = "0.2"
 backtrace = "0.3"
 bincode = "1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,10 @@ name = "sender-self"
 test = false
 harness = false
 [[test]]
+name = "spawn-env"
+test = false
+harness = false
+[[test]]
 name = "spawn-multiple-futures-send-recv-stream"
 test = false
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ serde_traitobject = "0.2"
 serde_json = "1.0"
 serde_pipe = "0.1"
 tcp_typed = "0.1"
-tokio = { version = "0.2.0-alpha.6", optional = true }
+tokio = { version = "0.2", optional = true }
 toml = "0.5"
 
 # dependency of kube; ensure it's vendored to simplify cross-compilation

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-    <a href="https://docs.rs/constellation-rs/0.1.8">Docs</a>
+    <a href="https://docs.rs/constellation-rs/0.1.9">Docs</a>
 </p>
 
 Constellation is a framework for Rust (nightly) that aides in the writing, debugging and deployment of distributed programs. It draws heavily from [Erlang/OTP](https://en.wikipedia.org/wiki/Erlang_(programming_language)), [MPI](https://en.wikipedia.org/wiki/Message_Passing_Interface), and [CSP](https://en.wikipedia.org/wiki/Communicating_sequential_processes); and leverages the Rust ecosystem where it can including [serde](https://serde.rs/) + [bincode](https://github.com/servo/bincode) for network serialization, and [mio](https://github.com/tokio-rs/mio) and [futures-rs](https://github.com/rust-lang-nursery/futures-rs) for asynchronous channels over TCP.
@@ -27,13 +27,13 @@ For leveraging Constellation directly, read on.
 
 ## Constellation framework
 
-* Constellation is a framework that's initialised with a call to [`init()`](https://docs.rs/constellation-rs/0.1.8/constellation/fn.init.html) at the beginning of your program.
-* You can [`spawn(closure)`](https://docs.rs/constellation-rs/0.1.8/constellation/fn.spawn.html) new processes, which run `closure`.
+* Constellation is a framework that's initialised with a call to [`init()`](https://docs.rs/constellation-rs/0.1.9/constellation/fn.init.html) at the beginning of your program.
+* You can [`spawn(closure)`](https://docs.rs/constellation-rs/0.1.9/constellation/fn.spawn.html) new processes, which run `closure`.
 * `spawn(closure)` returns the Pid of the new process.
-* You can communicate between processes by creating channels with [`Sender::new(remote_pid)`](https://docs.rs/constellation-rs/0.1.8/constellation/struct.Sender.html#method.new) and [`Receiver::new(remote_pid)`](https://docs.rs/constellation-rs/0.1.8/constellation/struct.Receiver.html#method.new).
-* Channels can be used asynchronously with [`sender.send(value).await`](https://docs.rs/constellation-rs/0.1.8/constellation/struct.Sender.html#method.send) and [`receiver.recv().await`](https://docs.rs/constellation-rs/0.1.8/constellation/struct.Receiver.html#method.recv).
+* You can communicate between processes by creating channels with [`Sender::new(remote_pid)`](https://docs.rs/constellation-rs/0.1.9/constellation/struct.Sender.html#method.new) and [`Receiver::new(remote_pid)`](https://docs.rs/constellation-rs/0.1.9/constellation/struct.Receiver.html#method.new).
+* Channels can be used asynchronously with [`sender.send(value).await`](https://docs.rs/constellation-rs/0.1.9/constellation/struct.Sender.html#method.send) and [`receiver.recv().await`](https://docs.rs/constellation-rs/0.1.9/constellation/struct.Receiver.html#method.recv).
 * [futures-rs](https://github.com/rust-lang-nursery/futures-rs) provides useful functions and adapters including `select()` and `join()` for working with channels.
-* You can also block on channels with the [`.block()`](https://docs.rs/constellation-rs/0.1.8/constellation/trait.FutureExt1.html#method.block) convenience method: `sender.send().block()` and `receiver.recv().block()`.
+* You can also block on channels with the [`.block()`](https://docs.rs/constellation-rs/0.1.9/constellation/trait.FutureExt1.html#method.block) convenience method: `sender.send().block()` and `receiver.recv().block()`.
 * For more information on asynchronous programming in Rust check out the [Async Book](https://rust-lang.github.io/async-book/index.html)!
 
 Here's a simple example recursively spawning processes to distribute the task of finding Fibonacci numbers:
@@ -248,7 +248,7 @@ Please file an issue if you experience any other requirements.
 
 ## API
 
-[see Rust doc](https://docs.rs/constellation-rs/0.1.8)
+[see Rust doc](https://docs.rs/constellation-rs/0.1.9)
 
 ## Testing
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
       endpoint: alecmocatta
       default:
         rust_toolchain: nightly
-        rust_lint_toolchain: nightly-2019-11-14
+        rust_lint_toolchain: nightly-2020-01-18
         rust_flags: ''
         rust_features: 'no_alloc;no_alloc distribute_binaries'
         rust_target_check: ''

--- a/constellation-internal/Cargo.toml
+++ b/constellation-internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constellation-internal"
-version = "0.1.8"
+version = "0.1.9"
 license = "Apache-2.0"
 authors = ["Alec Mocatta <alec@mocatta.net>"]
 categories = ["development-tools","network-programming","concurrency","asynchronous"]
@@ -10,7 +10,7 @@ Common components for the `constellation` framework.
 """
 repository = "https://github.com/alecmocatta/constellation"
 homepage = "https://github.com/alecmocatta/constellation"
-documentation = "https://docs.rs/constellation-internal/0.1.8"
+documentation = "https://docs.rs/constellation-internal/0.1.9"
 edition = "2018"
 
 [features]

--- a/constellation-internal/src/ext.rs
+++ b/constellation-internal/src/ext.rs
@@ -153,7 +153,7 @@ pub fn parse_mem_size(input: &str) -> Result<u64, ()> {
 	if index == input.len() {
 		return Ok(a);
 	}
-	let (b, b1): (u64, u32) = if input[index..=index].chars().nth(0).ok_or(())? == '.' {
+	let (b, b1): (u64, u32) = if input[index..=index].chars().next().ok_or(())? == '.' {
 		index += 1;
 		let index1 = index;
 		index = index
@@ -172,7 +172,7 @@ pub fn parse_mem_size(input: &str) -> Result<u64, ()> {
 	} else {
 		(0, 0)
 	};
-	if index + 1 < input.len() && input[index..=index].chars().nth(0).ok_or(())? == ' ' {
+	if index + 1 < input.len() && input[index..=index].chars().next().ok_or(())? == ' ' {
 		index += 1;
 	}
 	let c: u64 = match &input[index..] {
@@ -203,7 +203,7 @@ pub fn parse_cpu_size(input: &str) -> Result<u32, ()> {
 	if index == input.len() {
 		return Ok(a * 65536);
 	}
-	let (b, b1): (u64, u32) = if input[index..=index].chars().nth(0).ok_or(())? == '.' {
+	let (b, b1): (u64, u32) = if input[index..=index].chars().next().ok_or(())? == '.' {
 		index += 1;
 		let index1 = index;
 		index = index

--- a/constellation-internal/src/lib.rs
+++ b/constellation-internal/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/constellation-internal/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/constellation-internal/0.1.9")]
 #![warn(
 	// missing_copy_implementations,
 	missing_debug_implementations,

--- a/constellation-internal/src/lib.rs
+++ b/constellation-internal/src/lib.rs
@@ -20,7 +20,8 @@
 	clippy::if_not_else,
 	clippy::inline_always,
 	clippy::must_use_candidate,
-	clippy::double_must_use
+	clippy::double_must_use,
+	clippy::missing_errors_doc
 )]
 
 mod ext;
@@ -280,8 +281,8 @@ pub enum Format {
 /// ```
 /// # use constellation_internal::Resources;
 /// pub const RESOURCES_DEFAULT: Resources = Resources {
-/// 	mem: 100 * 1024 * 1024, // 100 MiB
-/// 	cpu: 65536 / 16,        // 1/16th of a logical CPU core
+///     mem: 100 * 1024 * 1024, // 100 MiB
+///     cpu: 65536 / 16,        // 1/16th of a logical CPU core
 /// };
 /// ```
 #[derive(Copy, Clone, PartialEq, Serialize, Deserialize, Debug)]
@@ -301,8 +302,8 @@ impl Default for Resources {
 /// ```
 /// # use constellation_internal::Resources;
 /// pub const RESOURCES_DEFAULT: Resources = Resources {
-/// 	mem: 100 * 1024 * 1024, // 100 MiB
-/// 	cpu: 65536 / 16,        // 1/16th of a logical CPU core
+///     mem: 100 * 1024 * 1024, // 100 MiB
+///     cpu: 65536 / 16,        // 1/16th of a logical CPU core
 /// };
 /// ```
 pub const RESOURCES_DEFAULT: Resources = Resources {

--- a/k8s.yaml
+++ b/k8s.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       containers:
         - name: constellation
-          image: constellationrs/constellation:0.1.8
+          image: constellationrs/constellation:0.1.9
           args:
             - kube
             - 0.0.0.0:32123
@@ -68,7 +68,7 @@ spec:
     spec:
       containers:
         - name: constellation
-          image: constellationrs/constellation:0.1.8
+          image: constellationrs/constellation:0.1.9
           args:
             - 0.0.0.0:32123
           env:

--- a/src/bin/cargo-deploy.rs
+++ b/src/bin/cargo-deploy.rs
@@ -53,7 +53,7 @@ fn main() {
 			if artifact.target.kind == vec![String::from("bin")] {
 				assert_eq!(artifact.filenames.len(), 1);
 				assert!(bin.is_none());
-				bin = Some(artifact.filenames.into_iter().nth(0).unwrap());
+				bin = Some(artifact.filenames.into_iter().next().unwrap());
 			}
 		}
 	}

--- a/src/bin/cargo-deploy.rs
+++ b/src/bin/cargo-deploy.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Usage
 //! ```text
-//! cargo deploy [options] <host> [--] [args]...
+//! cargo deploy [options] <host> [--] [<args>]...
 //! ```
 //!
 //! ## Options

--- a/src/bin/deploy.rs
+++ b/src/bin/deploy.rs
@@ -3,7 +3,7 @@
 //!
 //! ## Usage
 //! ```text
-//! deploy [options] <host> <binary> [--] [args]...
+//! deploy [options] <host> <binary> [--] [<args>]...
 //! ```
 //!
 //! ## Options
@@ -41,7 +41,7 @@ use constellation_internal::{
 const USAGE: &str = "Run a binary on a constellation cluster.
 
 USAGE:
-    deploy [options] <host> <binary> [--] [args]...
+    deploy [options] <host> <binary> [--] [<args>]...
 
 OPTIONS:
     -h --help          Show this screen.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! The only requirement to use is that [`init()`](init) must be called immediately inside your application's `main()` function.
 
-#![doc(html_root_url = "https://docs.rs/constellation-rs/0.1.8")]
+#![doc(html_root_url = "https://docs.rs/constellation-rs/0.1.9")]
 #![cfg_attr(feature = "nightly", feature(read_initializer))]
 #![warn(
 	missing_copy_implementations,

--- a/tests/sender-duplicate.rs
+++ b/tests/sender-duplicate.rs
@@ -1,7 +1,7 @@
 //= {
 //=   "output": {
 //=     "2": [
-//=       "thread 'main' panicked at 'Sender::<.*>::new\\(\\) called for pid [a-z0-9]{7} when a Sender to this pid already exists', src/.*\\.rs:[0-9]+:[0-9]+\n",
+//=       "thread 'main' panicked at 'Sender::<.*>::new\\(\\) called for pid [a-z0-9]{7} when a Sender to this pid already exists', (src/.*\\.rs|<::std::macros::panic macros>):[0-9]+:[0-9]+\n",
 //=       true
 //=     ],
 //=     "1": [

--- a/tests/sender-self.rs
+++ b/tests/sender-self.rs
@@ -5,7 +5,7 @@
 //=       true
 //=     ],
 //=     "2": [
-//=       "thread 'main' panicked at 'Sender::<.*>::new\\(\\) called with process's own pid\\. A process cannot create a channel to itself\\.', src/.*\\.rs:[0-9]+:[0-9]+\n",
+//=       "thread 'main' panicked at 'Sender::<.*>::new\\(\\) called with process's own pid\\. A process cannot create a channel to itself\\.', (src/.*\\.rs|<::std::macros::panic macros>):[0-9]+:[0-9]+\n",
 //=       true
 //=     ]
 //=   },

--- a/tests/spawn-env.rs
+++ b/tests/spawn-env.rs
@@ -1,0 +1,84 @@
+//= {
+//=   "output": {
+//=     "2": [
+//=       "",
+//=       true
+//=     ],
+//=     "1": [
+//=       "",
+//=       true
+//=     ]
+//=   },
+//=   "children": [
+//=     {
+//=       "output": {
+//=         "2": [
+//=           "",
+//=           true
+//=         ],
+//=         "1": [
+//=           "",
+//=           true
+//=         ]
+//=       },
+//=       "children": [],
+//=       "exit": "Success"
+//=     },
+//=     {
+//=       "output": {
+//=         "2": [
+//=           "",
+//=           true
+//=         ],
+//=         "1": [
+//=           "",
+//=           true
+//=         ]
+//=       },
+//=       "children": [],
+//=       "exit": "Success"
+//=     }
+//=   ],
+//=   "exit": "Success"
+//= }
+
+#![allow(clippy::unused_unit)] // for FnOnce!
+
+use constellation::*;
+use serde_closure::FnOnce;
+use std::env;
+
+fn main() {
+	init(Resources {
+		mem: 20 * 1024 * 1024,
+		..Resources::default()
+	});
+	let env = (
+		env::args().collect::<Vec<_>>(),
+		env::vars()
+			.filter(|&(ref key, _)| key != "CONSTELLATION" && key != "CONSTELLATION_RESOURCES")
+			.collect::<Vec<_>>(),
+	);
+	for _ in 0..2 {
+		let env = env.clone();
+		let _pid = spawn(
+			Resources {
+				mem: 20 * 1024 * 1024,
+				..Resources::default()
+			},
+			FnOnce!(|_parent| {
+				let env2 = (
+					env::args().collect::<Vec<_>>(),
+					env::vars()
+						.filter(|&(ref key, _)| {
+							key != "CONSTELLATION" && key != "CONSTELLATION_RESOURCES"
+						})
+						.collect::<Vec<_>>(),
+				);
+				assert_eq!(env, env2);
+			}),
+		)
+		.block()
+		.expect("spawn() failed to allocate process");
+	}
+}

--- a/tests/tester/ext.rs
+++ b/tests/tester/ext.rs
@@ -69,8 +69,8 @@ pub mod serde_regex {
 		S: Serializer,
 	{
 		let x = value.as_str();
-		assert_eq!(x.chars().nth(0).unwrap(), '^');
-		assert_eq!(x.chars().rev().nth(0).unwrap(), '$');
+		assert_eq!(x.chars().next().unwrap(), '^');
+		assert_eq!(x.chars().rev().next().unwrap(), '$');
 		serializer.serialize_str(&x[1..x.len() - 1])
 	}
 	pub fn deserialize<'de, D>(deserializer: D) -> Result<Regex, D::Error>

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -314,7 +314,7 @@ fn main() {
 					// assert_eq!(artifact.filenames.len(), 1, "{:?}", artifact);
 					let x = products.insert(
 						path.to_owned(),
-						artifact.filenames.into_iter().nth(0).unwrap(),
+						artifact.filenames.into_iter().next().unwrap(),
 					);
 					assert!(x.is_none());
 				}


### PR DESCRIPTION
* fix #51 and add a test to check `env::args()` and `env::vars()` are correctly passed around
* update tokio now 0.2 has been published
* update the rust lint toolchain
* publish v0.1.9