### PR TITLE
ensure pids are unique

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+[*]
+tab_width = 4
+
+[.*]
+tab_width = 4

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,11 +4,10 @@ pull_request_rules:
       - base=master
       - status-success=tests
       - status-success=ci/dockercloud
-      - label!=work-in-progress
+      - "label!=work in progress"
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge
@@ -19,11 +18,10 @@ pull_request_rules:
       - base=master
       - status-success=tests
       - status-success=ci/dockercloud
-      - label!=work-in-progress
+      - "label!=work in progress"
       - author=alecmocatta # https://github.com/Mergifyio/mergify-engine/issues/451
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"
-      - "#commented-reviews-by=0"
     actions:
       merge:
         method: merge
@@ -38,10 +36,10 @@ pull_request_rules:
       - "title~=^WIP: .*"
     actions:
       label:
-        add: ["work-in-progress"]
+        add: ["work in progress"]
   - name: auto remove wip label
     conditions:
       - "-title~=^WIP: .*"
     actions:
       label:
-        remove: ["work-in-progress"]
+        remove: ["work in progress"]

--- a/constellation-internal/Cargo.toml
+++ b/constellation-internal/Cargo.toml
@@ -18,7 +18,6 @@ distribute_binaries = []
 no_alloc = ["alloc_counter"]
 
 [dependencies]
-aes = "0.3"
 alloc_counter = { optional = true, version = "0.0", default-features = false, features = ["std", "no_alloc"] }
 ansi_term = "0.12"
 bincode = "1.0"

--- a/constellation-internal/src/lib.rs
+++ b/constellation-internal/src/lib.rs
@@ -33,7 +33,7 @@ use nix::{fcntl, libc, sys::signal, unistd};
 use palaver::file::{copy, memfd_create};
 use serde::{Deserialize, Serialize};
 use std::{
-	convert::{TryFrom, TryInto}, env, error::Error, ffi::{CString, OsString}, fmt::{self, Debug, Display}, fs::File, io::{self, Read, Seek, Write}, net, ops, os::unix::{
+	convert::{TryFrom, TryInto}, env, error::Error, ffi::{CString, OsString}, fmt::{self, Debug, Display}, fs::File, io::{self, Read, Seek, Write}, net::{IpAddr, SocketAddr}, ops, os::unix::{
 		ffi::OsStringExt, io::{AsRawFd, FromRawFd, IntoRawFd}
 	}, process::abort, sync::{Arc, Mutex}
 };
@@ -60,45 +60,25 @@ pub use format::*;
 ///
 /// All inter-process communication occurs after [Sender](Sender)s and [Receiver](Receiver)s have been created with their remotes' `Pid`s. Thus `Pid`s are the primary form of addressing in a `constellation` cluster.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct Pid([u8; 16]);
+pub struct Pid {
+	ip: IpAddr,
+	port: u16,
+	key: u128,
+}
 impl Pid {
-	pub(crate) fn new(ip: net::IpAddr, port: u16) -> Self {
-		match ip {
-			net::IpAddr::V4(ip) => {
-				let ip = ip.octets();
-				Self([
-					ip[0],
-					ip[1],
-					ip[2],
-					ip[3],
-					(port >> 8).try_into().unwrap(),
-					(port & 0xff).try_into().unwrap(),
-					0,
-					0,
-					0,
-					0,
-					0,
-					0,
-					0,
-					0,
-					0,
-					0,
-				])
-			}
-			_ => unimplemented!(),
-		}
+	pub(crate) fn new(ip: IpAddr, port: u16) -> Self {
+		assert_ne!(port, 0);
+		let key = rand::random();
+		Self { ip, port, key }
 	}
 
-	pub(crate) fn addr(&self) -> net::SocketAddr {
-		net::SocketAddr::new(
-			[self.0[0], self.0[1], self.0[2], self.0[3]].into(),
-			((u16::from(self.0[4])) << 8) | (u16::from(self.0[5])),
-		)
+	pub(crate) fn addr(&self) -> SocketAddr {
+		SocketAddr::new(self.ip, self.port)
 	}
 
 	fn format<'a>(&'a self) -> impl Iterator<Item = char> + 'a {
-		let key: [u8; 16] = [0; 16];
-		encrypt(self.0, key)
+		self.key
+			.to_le_bytes()
 			.to_hex()
 			.collect::<Vec<_>>()
 			.into_iter()
@@ -112,21 +92,21 @@ impl Display for Pid {
 impl Debug for Pid {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_tuple("Pid")
-			.field(&self.format().collect::<String>())
+			.field(&self.format().take(7).collect::<String>())
 			.finish()
 	}
 }
 pub trait PidInternal {
-	fn new(ip: net::IpAddr, port: u16) -> Pid;
-	fn addr(&self) -> net::SocketAddr;
+	fn new(ip: IpAddr, port: u16) -> Pid;
+	fn addr(&self) -> SocketAddr;
 }
 #[doc(hidden)]
 impl PidInternal for Pid {
-	fn new(ip: net::IpAddr, port: u16) -> Self {
+	fn new(ip: IpAddr, port: u16) -> Self {
 		Self::new(ip, port)
 	}
 
-	fn addr(&self) -> net::SocketAddr {
+	fn addr(&self) -> SocketAddr {
 		Self::addr(self)
 	}
 }

--- a/constellation-internal/src/lib.rs
+++ b/constellation-internal/src/lib.rs
@@ -76,23 +76,24 @@ impl Pid {
 		SocketAddr::new(self.ip, self.port)
 	}
 
-	fn format<'a>(&'a self) -> impl Iterator<Item = char> + 'a {
+	fn format<'a>(&'a self) -> impl Iterator<Item = char> + Clone + 'a {
 		self.key
 			.to_le_bytes()
 			.to_hex()
+			.take(7)
 			.collect::<Vec<_>>()
 			.into_iter()
 	}
 }
 impl Display for Pid {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-		write!(f, "{}", self.format().take(7).collect::<String>())
+		write!(f, "{}", self.format().collect::<String>())
 	}
 }
 impl Debug for Pid {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		f.debug_tuple("Pid")
-			.field(&self.format().take(7).collect::<String>())
+			.field(&self.format().collect::<String>())
 			.finish()
 	}
 }

--- a/constellation-internal/src/msg.rs
+++ b/constellation-internal/src/msg.rs
@@ -1,7 +1,28 @@
-use crate::Resources;
+use ::serde::{Deserialize, Serialize};
 #[cfg(not(feature = "distribute_binaries"))]
 use std::marker::PhantomData;
-use std::{ffi::OsString, net::SocketAddr};
+use std::{
+	ffi::OsString, net::{IpAddr, SocketAddr}
+};
+
+use crate::{Pid, Resources};
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct SchedulerArg {
+	pub ip: IpAddr,
+	pub scheduler: Pid,
+}
+
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct SpawnArg<T> {
+	pub bridge: Pid,
+	pub spawn: Option<SpawnArgSub<T>>,
+}
+#[derive(Clone, Serialize, Deserialize, Debug)]
+pub struct SpawnArgSub<T> {
+	pub parent: Pid,
+	pub f: T,
+}
 
 #[derive(Debug)]
 pub struct FabricRequest<A, B>

--- a/src/bin/constellation/bridge.rs
+++ b/src/bin/constellation/bridge.rs
@@ -37,7 +37,9 @@ use std::{
 
 use constellation::FutureExt1;
 use constellation_internal::{
-	abort_on_unwind, abort_on_unwind_1, forbid_alloc, map_bincode_err, msg::{bincode_deserialize_from, bincode_serialize_into, BridgeRequest, FabricRequest}, BufferedStream, DeployInputEvent, DeployOutputEvent, ExitStatus, Fd, Pid, ProcessInputEvent, ProcessOutputEvent, Resources, TrySpawnError
+	abort_on_unwind, abort_on_unwind_1, forbid_alloc, map_bincode_err, msg::{
+		bincode_deserialize_from, bincode_serialize_into, BridgeRequest, FabricRequest, SpawnArg
+	}, BufferedStream, DeployInputEvent, DeployOutputEvent, ExitStatus, Fd, Pid, ProcessInputEvent, ProcessOutputEvent, Resources, TrySpawnError
 };
 
 const SCHEDULER_FD: Fd = 4;
@@ -278,7 +280,11 @@ fn manage_connection(
 		.map_err(map_bincode_err)
 		.map_err(drop)?;
 	assert_eq!(request.arg.len(), 0);
-	bincode::serialize_into(&mut request.arg, &constellation::pid()).unwrap();
+	let spawn_arg = SpawnArg::<()> {
+		bridge: constellation::pid(),
+		spawn: None,
+	};
+	bincode::serialize_into(&mut request.arg, &spawn_arg).unwrap();
 	let resources = request
 		.resources
 		.or_else(|| {

--- a/src/bin/constellation/main.rs
+++ b/src/bin/constellation/main.rs
@@ -84,7 +84,7 @@ use palaver::{
 	file::{copy_fd, execve, fexecve, move_fds}, socket::{socket, SockFlag}, valgrind
 };
 use std::{
-	collections::HashMap, convert::{TryFrom, TryInto}, env, io, net::{IpAddr, SocketAddr, TcpListener}, process, sync, thread
+	collections::HashMap, convert::{TryFrom, TryInto}, env, io, io::Seek, net::{IpAddr, SocketAddr, TcpListener}, process, sync, thread
 };
 #[cfg(unix)]
 use std::{
@@ -258,6 +258,9 @@ fn main() {
 				}
 				.port();
 				let process_id = Pid::new(ip, port);
+				let _ = (&request.arg).seek(std::io::SeekFrom::End(0)).unwrap();
+				bincode::serialize_into(&request.arg, &process_id).unwrap();
+				let _ = (&request.arg).seek(std::io::SeekFrom::Start(0)).unwrap();
 
 				let args = request
 					.args


### PR DESCRIPTION
Long running processes can have issues with `Pid`s being reused.

This PR inserts 128 bits of random data into `Pid`s to ensure they are actually unique.