### PR TITLE
Robust process cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ systemstat = "0.1"
 
 [patch.crates-io]
 systemstat = { git = "https://github.com/alecmocatta/systemstat" }
+palaver = { git = "https://github.com/alecmocatta/palaver", branch = "fork2" }
 
 ###
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ toml = "0.5"
 openssl = { version = "0.10", features = ["vendored"], optional = true }
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.15"
+nix = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 winapi = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ kube = { version = "0.23", features = ["openapi"], optional = true }
 log = "0.4"
 notifier = { version = "0.1", features = ["tcp_typed"] }
 once_cell = "1.0"
-palaver = "0.2.8"
+palaver = "0.3.0-alpha.1"
 pin-utils = "0.1.0-alpha.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,6 @@ systemstat = "0.1"
 
 [patch.crates-io]
 systemstat = { git = "https://github.com/alecmocatta/systemstat" }
-palaver = { git = "https://github.com/alecmocatta/palaver", branch = "fork2" }
 
 ###
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,34 +33,34 @@ jobs:
         #   rust_target_run: 'x86_64-pc-windows-msvc i686-pc-windows-msvc' # currently broken building crate-type=lib: x86_64-pc-windows-gnu i686-pc-windows-gnu
         mac0:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac1:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac2:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac3:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac4:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac5:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac6:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac7:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac8:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         mac9:
           imageName: 'macos-10.13'
-          rust_target_run: 'x86_64-apple-darwin' # i686-apple-darwin'
+          rust_target_run: 'x86_64-apple-darwin'
         linux0:
           imageName: 'ubuntu-16.04'
           rust_target_run: 'x86_64-unknown-linux-gnu' # i686-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-musl'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_check: ''
         rust_target_build: ''
         rust_target_run: ''
-        constellation_test_iterations: '5'
+        constellation_test_iterations: '50'
       matrix:
         # windows:
         #   imageName: 'vs2017-win2016'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_check: ''
         rust_target_build: ''
         rust_target_run: ''
-        constellation_test_iterations: '50'
+        constellation_test_iterations: '5'
       matrix:
         # windows:
         #   imageName: 'vs2017-win2016'

--- a/constellation-internal/Cargo.toml
+++ b/constellation-internal/Cargo.toml
@@ -30,7 +30,7 @@ serde_bytes = "0.11"
 serde_json = "1.0"
 
 [target.'cfg(unix)'.dependencies]
-nix = "0.15"
+nix = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [] }

--- a/src/bin/constellation/bridge.rs
+++ b/src/bin/constellation/bridge.rs
@@ -213,7 +213,6 @@ fn recce(
 			let _ = child1.signal(nix::sys::signal::Signal::SIGKILL);
 		}))
 		.unwrap();
-	// TODO: do this without waitpid/kill race
 	match child.wait() {
 		Ok(palaver::process::WaitStatus::Exited(0))
 		| Ok(palaver::process::WaitStatus::Signaled(nix::sys::signal::Signal::SIGKILL, _)) => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -777,7 +777,7 @@ fn native_bridge(format: Format, our_pid: Pid) -> Pid {
 	let (bridge_process_listener, bridge_pid) = native_process_listener();
 
 	// No threads spawned between init and here so we're good
-	assert_eq!(palaver::thread::count(), 1); // TODO: balks on 32 bit due to procinfo using usize that reflects target not host
+	assert_eq!(palaver::thread::count(), 1);
 	if let palaver::process::ForkResult::Parent(_) = palaver::process::fork(true).unwrap() {
 		// trace!("parent");
 
@@ -913,7 +913,7 @@ fn monitor_process(
 
 	// trace!("forking");
 	// No threads spawned between init and here so we're good
-	assert_eq!(palaver::thread::count(), 1); // TODO: balks on 32 bit due to procinfo using usize that reflects target not host
+	assert_eq!(palaver::thread::count(), 1);
 	let new = signal::SigAction::new(
 		signal::SigHandler::SigDfl,
 		signal::SaFlags::empty(),
@@ -1163,7 +1163,7 @@ pub fn init(resources: Resources) {
 	// 	log::LevelFilter::Trace,
 	// )
 	// .unwrap();
-	assert_eq!(palaver::thread::count(), 1); // TODO: balks on 32 bit due to procinfo using usize that reflects target not host
+	assert_eq!(palaver::thread::count(), 1);
 	if valgrind::is().unwrap_or(false) {
 		let _ = unistd::close(valgrind::start_fd() - 1 - 12); // close non CLOEXEC'd fd of this binary
 	}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,8 +44,8 @@ use futures::{
 };
 use log::trace;
 use nix::{
-	errno, fcntl, libc, sys::{
-		signal, socket::{self, sockopt}, stat, wait
+	fcntl, libc, sys::{
+		signal, socket::{self, sockopt}, stat
 	}, unistd
 };
 use once_cell::sync::{Lazy, OnceCell};
@@ -544,88 +544,63 @@ fn spawn_native(
 	))
 	.unwrap();
 
-	let _child_pid = match unistd::fork().expect("Fork failed") {
-		unistd::ForkResult::Child => {
-			forbid_alloc(|| {
-				// Memory can be in a weird state now. Imagine a thread has just taken out a lock,
-				// but we've just forked. Lock still held. Avoid deadlock by doing nothing fancy here.
-				// Including malloc.
+	if let palaver::process::ForkResult::Child = palaver::process::fork(true).expect("Fork failed")
+	{
+		forbid_alloc(|| {
+			// Memory can be in a weird state now. Imagine a thread has just taken out a lock,
+			// but we've just forked. Lock still held. Avoid deadlock by doing nothing fancy here.
+			// Including malloc.
 
-				// let err = unsafe{libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL)}; assert_eq!(err, 0);
-				unsafe {
-					let _ = signal::sigaction(
-						signal::SIGCHLD,
-						&signal::SigAction::new(
-							signal::SigHandler::SigDfl,
-							signal::SaFlags::empty(),
-							signal::SigSet::empty(),
-						),
-					)
-					.unwrap();
-				};
+			let valgrind_start_fd = if valgrind::is().unwrap_or(false) {
+				Some(valgrind::start_fd())
+			} else {
+				None
+			};
+			// FdIter uses libc::opendir which mallocs. Underlying syscall is getdents…
+			// FdIter::new().unwrap()
+			for fd in (0..1024).filter(|&fd| {
+				fd >= 3
+					&& fd != process_listener
+					&& fd != arg.as_raw_fd()
+					&& (valgrind_start_fd.is_none() || fd < valgrind_start_fd.unwrap())
+			}) {
+				let _ = unistd::close(fd); //.unwrap();
+			}
 
-				let valgrind_start_fd = if valgrind::is().unwrap_or(false) {
-					Some(valgrind::start_fd())
-				} else {
-					None
-				};
-				// FdIter uses libc::opendir which mallocs. Underlying syscall is getdents…
-				// FdIter::new().unwrap()
-				for fd in (0..1024).filter(|&fd| {
-					fd >= 3
-						&& fd != process_listener
-						&& fd != arg.as_raw_fd() && (valgrind_start_fd.is_none()
-						|| fd < valgrind_start_fd.unwrap())
-				}) {
-					let _ = unistd::close(fd); //.unwrap();
-				}
+			if process_listener != LISTENER_FD {
+				palaver::file::move_fd(
+					process_listener,
+					LISTENER_FD,
+					Some(fcntl::FdFlag::empty()),
+					true,
+				)
+				.unwrap();
+			}
+			if arg.as_raw_fd() != ARG_FD {
+				palaver::file::move_fd(arg.as_raw_fd(), ARG_FD, Some(fcntl::FdFlag::empty()), true)
+					.unwrap();
+			}
 
-				if process_listener != LISTENER_FD {
-					palaver::file::move_fd(
-						process_listener,
-						LISTENER_FD,
-						Some(fcntl::FdFlag::empty()),
-						true,
-					)
+			if !valgrind::is().unwrap_or(false) {
+				execve(&exe, &args, &vars)
+					.expect("Failed to execve /proc/self/exe for spawn_native");
+			} else {
+				let fd = fcntl::open::<path::PathBuf>(
+					&fd_path(valgrind_start_fd.unwrap()).unwrap(),
+					fcntl::OFlag::O_RDONLY | fcntl::OFlag::O_CLOEXEC,
+					stat::Mode::empty(),
+				)
+				.unwrap();
+				let binary_desired_fd_ = valgrind_start_fd.unwrap() - 1;
+				assert!(binary_desired_fd_ > fd);
+				palaver::file::move_fd(fd, binary_desired_fd_, Some(fcntl::FdFlag::empty()), true)
 					.unwrap();
-				}
-				if arg.as_raw_fd() != ARG_FD {
-					palaver::file::move_fd(
-						arg.as_raw_fd(),
-						ARG_FD,
-						Some(fcntl::FdFlag::empty()),
-						true,
-					)
-					.unwrap();
-				}
-
-				if !valgrind::is().unwrap_or(false) {
-					execve(&exe, &args, &vars)
-						.expect("Failed to execve /proc/self/exe for spawn_native");
-				} else {
-					let fd = fcntl::open::<path::PathBuf>(
-						&fd_path(valgrind_start_fd.unwrap()).unwrap(),
-						fcntl::OFlag::O_RDONLY | fcntl::OFlag::O_CLOEXEC,
-						stat::Mode::empty(),
-					)
-					.unwrap();
-					let binary_desired_fd_ = valgrind_start_fd.unwrap() - 1;
-					assert!(binary_desired_fd_ > fd);
-					palaver::file::move_fd(
-						fd,
-						binary_desired_fd_,
-						Some(fcntl::FdFlag::empty()),
-						true,
-					)
-					.unwrap();
-					fexecve(binary_desired_fd_, &args, &vars)
-						.expect("Failed to fexecve /proc/self/fd/n for spawn_native");
-				}
-				unreachable!();
-			})
-		}
-		unistd::ForkResult::Parent { child, .. } => child,
-	};
+				fexecve(binary_desired_fd_, &args, &vars)
+					.expect("Failed to fexecve /proc/self/fd/n for spawn_native");
+			}
+			unreachable!();
+		})
+	}
 	unistd::close(process_listener).unwrap();
 	drop(arg);
 	// *BRIDGE.get().as_ref().unwrap().0.send(ProcessOutputEvent::Spawn(new_pid)).unwrap();
@@ -803,7 +778,7 @@ fn native_bridge(format: Format, our_pid: Pid) -> Pid {
 
 	// No threads spawned between init and here so we're good
 	assert_eq!(palaver::thread::count(), 1); // TODO: balks on 32 bit due to procinfo using usize that reflects target not host
-	if let unistd::ForkResult::Parent { .. } = unistd::fork().unwrap() {
+	if let palaver::process::ForkResult::Parent(_) = palaver::process::fork(true).unwrap() {
 		// trace!("parent");
 
 		palaver::file::move_fd(
@@ -827,22 +802,6 @@ fn native_bridge(format: Format, our_pid: Pid) -> Pid {
 		let err = unsafe { libc::atexit(at_exit) };
 		assert_eq!(err, 0);
 
-		let x = thread::Builder::new()
-			.name(String::from("bridge-waitpid"))
-			.spawn(abort_on_unwind(|| {
-				loop {
-					match wait::waitpid(None, None) {
-						Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => (),
-						Ok(wait::WaitStatus::Exited(_pid, code)) if code == 0 => (), //assert_eq!(pid, child),
-						// wait::WaitStatus::Signaled(pid, signal, _) if signal == signal::Signal::SIGKILL => assert_eq!(pid, child),
-						Err(nix::Error::Sys(errno::Errno::ECHILD)) => break,
-						wait_status => {
-							panic!("bad exit: {:?}", wait_status); /*loop {thread::sleep_ms(1000)}*/
-						}
-					}
-				}
-			}))
-			.unwrap();
 		let mut exit_code = ExitStatus::Success;
 		let (stdout, stderr) = (io::stdout(), io::stderr());
 		let mut formatter = if let Format::Human = format {
@@ -899,7 +858,6 @@ fn native_bridge(format: Format, our_pid: Pid) -> Pid {
 				}
 			}
 		}
-		x.join().unwrap();
 		process::exit(exit_code.into());
 	}
 	unistd::close(bridge_process_listener).unwrap();
@@ -956,7 +914,18 @@ fn monitor_process(
 	// trace!("forking");
 	// No threads spawned between init and here so we're good
 	assert_eq!(palaver::thread::count(), 1); // TODO: balks on 32 bit due to procinfo using usize that reflects target not host
-	if let unistd::ForkResult::Parent { child } = unistd::fork().unwrap() {
+	let old = unsafe {
+		signal::sigaction(
+			signal::SIGCHLD,
+			&signal::SigAction::new(
+				signal::SigHandler::SigDfl,
+				signal::SaFlags::empty(),
+				signal::SigSet::empty(),
+			),
+		)
+		.unwrap()
+	};
+	if let palaver::process::ForkResult::Parent(child) = palaver::process::fork(false).unwrap() {
 		unistd::close(reader).unwrap();
 		unistd::close(monitor_writer).unwrap();
 		unistd::close(stdout_writer).unwrap();
@@ -1089,9 +1058,9 @@ fn monitor_process(
 								}
 								ProcessInputEvent::Kill => {
 									// TODO: this is racey
-									signal::kill(child, signal::Signal::SIGKILL).unwrap_or_else(
-										|e| assert_eq!(e, nix::Error::Sys(errno::Errno::ESRCH)),
-									);
+									// child.signal(signal::Signal::SIGKILL).unwrap_or_else(|e| {
+									// 	assert_eq!(e, nix::Error::Sys(errno::Errno::ESRCH))
+									// });
 								}
 							}
 						}
@@ -1108,25 +1077,8 @@ fn monitor_process(
 		);
 		// trace!("awaiting exit");
 
-		let exit = loop {
-			match wait::waitpid(child, None) {
-				Err(nix::Error::Sys(nix::errno::Errno::EINTR)) => (),
-				exit => break exit,
-			}
-		}
-		.unwrap();
-		// 		Ok(exit) => break exit,
-		// if let Err(nix::Error::Sys(nix::errno::Errno::EINTR)) = exit {
-		// 	loop {
-		// 		thread::sleep(std::time::Duration::new(1,0));
-		// 	}
-		// }
-		// if exit.is_err() {
-		// 	loop {
-		// 		thread::sleep(std::time::Duration::new(1,0));
-		// 	}
-		// }
-		// let exit = exit.unwrap();
+		let exit = child.wait().unwrap();
+
 		trace!(
 			"PROCESS {}:{}: exited {:?}",
 			unistd::getpid(),
@@ -1149,15 +1101,12 @@ fn monitor_process(
 		let _ = deployed;
 
 		let code = match exit {
-			wait::WaitStatus::Exited(pid, code) => {
-				assert_eq!(pid, child);
+			palaver::process::WaitStatus::Exited(code) => {
 				ExitStatus::from_unix_status(code.try_into().unwrap())
 			}
-			wait::WaitStatus::Signaled(pid, signal, _) => {
-				assert_eq!(pid, child);
+			palaver::process::WaitStatus::Signaled(signal, _) => {
 				ExitStatus::from_unix_signal(signal)
 			}
-			_ => panic!(),
 		};
 		// trace!("joining stdout_thread");
 		stdout_thread.join().unwrap();
@@ -1189,11 +1138,7 @@ fn monitor_process(
 		unistd::close(stderr_reader.unwrap()).unwrap();
 	}
 	unistd::close(stdout_reader).unwrap();
-	#[cfg(any(target_os = "android", target_os = "linux"))]
-	{
-		let err = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL) };
-		assert_eq!(err, 0);
-	}
+	let _ = unsafe { signal::sigaction(signal::SIGCHLD, &old).unwrap() };
 	trace!("awaiting ready");
 	let err = unistd::read(reader, &mut [0]).unwrap();
 	assert_eq!(err, 0);
@@ -1260,7 +1205,6 @@ pub fn init(resources: Resources) {
 					.unwrap();
 				}
 				let bridge = native_bridge(format, our_pid);
-				// let err = unsafe{libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL)}; assert_eq!(err, 0);
 				let spawn_arg = SpawnArg {
 					bridge,
 					spawn: None,
@@ -1300,14 +1244,10 @@ pub fn init(resources: Resources) {
 		}
 	};
 
-	// trace!(
-	// 	"PROCESS {}:{}: start setup; pid: {}",
-	// 	unistd::getpid(),
-	// 	pid().addr().port(),
-	// 	pid()
-	// );
-
 	PID.set(our_pid).unwrap();
+	DEPLOYED.set(deployed).unwrap();
+	RESOURCES.set(resources).unwrap();
+	BRIDGE.set(argument.bridge).unwrap();
 
 	trace!(
 		"PROCESS {}:{}: start setup; pid: {}",
@@ -1315,10 +1255,6 @@ pub fn init(resources: Resources) {
 		pid().addr().port(),
 		pid()
 	);
-
-	DEPLOYED.set(deployed).unwrap();
-	RESOURCES.set(resources).unwrap();
-	BRIDGE.set(argument.bridge).unwrap();
 
 	let fd = fcntl::open("/dev/null", fcntl::OFlag::O_RDWR, stat::Mode::empty()).unwrap();
 	if fd != SCHEDULER_FD {
@@ -1385,18 +1321,6 @@ pub fn init(resources: Resources) {
 
 	let err = unsafe { libc::atexit(at_exit) };
 	assert_eq!(err, 0);
-
-	unsafe {
-		let _ = signal::sigaction(
-			signal::SIGCHLD,
-			&signal::SigAction::new(
-				signal::SigHandler::SigIgn,
-				signal::SaFlags::empty(),
-				signal::SigSet::empty(),
-			),
-		)
-		.unwrap();
-	};
 
 	trace!(
 		"PROCESS {}:{}: done setup; pid: {}; bridge: {:?}",

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -463,16 +463,16 @@ fn main() {
 	fabric.kill().unwrap();
 	println!("waiting");
 	let _ = fabric.wait().unwrap();
-	#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-	{
-		println!("waiting stderr");
-		let _stderr_empty = fabric_stderr.join().unwrap();
-		// assert!(stderr_empty);
-		println!("waiting stdout");
-		let _stdout_empty = fabric_stdout.join().unwrap();
-		// assert!(stdout_empty);
-	}
-	#[cfg(any(target_os = "macos", target_os = "ios"))]
+	// #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+	// {
+	// 	println!("waiting stderr");
+	// 	let _stderr_empty = fabric_stderr.join().unwrap();
+	// 	// assert!(stderr_empty);
+	// 	println!("waiting stdout");
+	// 	let _stdout_empty = fabric_stdout.join().unwrap();
+	// 	// assert!(stdout_empty);
+	// }
+	// #[cfg(any(target_os = "macos", target_os = "ios"))]
 	{
 		let _ = (fabric_stderr, fabric_stdout);
 		let _ = process::Command::new("killall")

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -463,23 +463,12 @@ fn main() {
 	fabric.kill().unwrap();
 	println!("waiting");
 	let _ = fabric.wait().unwrap();
-	// #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-	// {
-	// 	println!("waiting stderr");
-	// 	let _stderr_empty = fabric_stderr.join().unwrap();
-	// 	// assert!(stderr_empty);
-	// 	println!("waiting stdout");
-	// 	let _stdout_empty = fabric_stdout.join().unwrap();
-	// 	// assert!(stdout_empty);
-	// }
-	// #[cfg(any(target_os = "macos", target_os = "ios"))]
-	{
-		let _ = (fabric_stderr, fabric_stdout);
-		let _ = process::Command::new("killall")
-			.arg("constellation")
-			.output()
-			.unwrap();
-	}
+	println!("waiting stderr");
+	let stderr_empty = fabric_stderr.join().unwrap();
+	assert!(stderr_empty);
+	println!("waiting stdout");
+	let _stdout_empty = fabric_stdout.join().unwrap();
+	// assert!(stdout_empty);
 
 	println!(
 		"{}/{} succeeded in {:?}",

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -461,11 +461,14 @@ fn main() {
 
 	println!("killing");
 	fabric.kill().unwrap();
+	println!("waiting");
 	let _ = fabric.wait().unwrap();
 	#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 	{
+		println!("waiting stderr");
 		let _stderr_empty = fabric_stderr.join().unwrap();
 		// assert!(stderr_empty);
+		println!("waiting stdout");
 		let _stdout_empty = fabric_stdout.join().unwrap();
 		// assert!(stdout_empty);
 	}


### PR DESCRIPTION
Use [`palaver`](https://github.com/alecmocatta/palaver)'s FreeBSD-inspired [`fork`](https://docs.rs/palaver/0.3.0-alpha.1/palaver/process/fn.fork.html), which ensures child processes are killed on their parent's death.

Native (i.e. `cargo run` rather than `cargo deploy`) execution currently orphans its child processes. As such these processes could outlive the top process, though in practise the SIG{INT,HUP,*} sent by the shell to the process group will terminate them. This could be fully solved but it's a slight performance tradeoff and I haven't quite figured out the most appropriate design.