### PR TITLE
Add tests for resource limits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,13 +54,13 @@ kube = { version = "0.23", features = ["openapi"], optional = true }
 log = "0.4"
 notifier = { version = "0.1", features = ["tcp_typed"] }
 once_cell = "1.0"
-palaver = "0.3.0-alpha.1"
+palaver = "0.3.0-alpha.2"
 pin-utils = "0.1.0-alpha.4"
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_closure = "0.2"
 serde_traitobject = "0.2"
-serde_json = "1.0"
+serde_json = { version = "1.0", features = ["unbounded_depth"] }
 serde_pipe = "0.1"
 tcp_typed = "0.1"
 tokio = { version = "0.2", optional = true }
@@ -80,6 +80,7 @@ doc-comment = "0.3"
 hex = "0.4"
 itertools = "0.8"
 multiset = "0.0"
+rand_pcg = { version = "0.2", features = ["serde1"] }
 regex = "1.0"
 sha1 = "0.6"
 systemstat = "0.1"
@@ -121,6 +122,14 @@ test = false
 harness = false
 [[test]]
 name = "output-data"
+test = false
+harness = false
+[[test]]
+name = "resource-limit-stress"
+test = false
+harness = false
+[[test]]
+name = "resource-limit"
 test = false
 harness = false
 [[test]]
@@ -177,6 +186,10 @@ test = false
 harness = false
 [[test]]
 name = "spawn-send-recv"
+test = false
+harness = false
+[[test]]
+name = "spawn-send-sleep"
 test = false
 harness = false
 [[test]]

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align="center">
     <a href="https://crates.io/crates/constellation-rs"><img src="https://img.shields.io/crates/v/constellation-rs.svg?maxAge=86400" alt="Crates.io" /></a>
     <a href="LICENSE.txt"><img src="https://img.shields.io/crates/l/constellation-rs.svg?maxAge=2592000" alt="Apache-2.0 licensed" /></a>
-    <a href="https://dev.azure.com/alecmocatta/constellation/_build/latest?definitionId=25&branchName=master"><img src="https://dev.azure.com/alecmocatta/constellation/_apis/build/status/tests?branchName=master" alt="Build Status" /></a>
+    <a href="https://dev.azure.com/alecmocatta/constellation/_build"><img src="https://dev.azure.com/alecmocatta/constellation/_apis/build/status/tests?branchName=master" alt="Build Status" /></a>
 </p>
 
 <p align="center">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_check: ''
         rust_target_build: ''
         rust_target_run: ''
-        constellation_test_iterations: '50'
+        constellation_test_iterations: '20'
       matrix:
         windows0:
           imageName: 'vs2017-win2016'
@@ -81,16 +81,46 @@ jobs:
           rust_target_run: 'x86_64-unknown-linux-gnu'
         linux5:
           imageName: 'ubuntu-16.04'
-          rust_target_run: 'x86_64-unknown-linux-musl'
+          rust_target_run: 'x86_64-unknown-linux-gnu'
         linux6:
           imageName: 'ubuntu-16.04'
-          rust_target_run: 'x86_64-unknown-linux-musl'
+          rust_target_run: 'x86_64-unknown-linux-gnu'
         linux7:
           imageName: 'ubuntu-16.04'
-          rust_target_run: 'x86_64-unknown-linux-musl'
+          rust_target_run: 'x86_64-unknown-linux-gnu'
         linux8:
           imageName: 'ubuntu-16.04'
-          rust_target_run: 'x86_64-unknown-linux-musl'
+          rust_target_run: 'x86_64-unknown-linux-gnu'
         linux9:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-gnu'
+        linux10:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux11:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux12:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux13:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux14:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux15:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux16:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux17:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux18:
+          imageName: 'ubuntu-16.04'
+          rust_target_run: 'x86_64-unknown-linux-musl'
+        linux19:
           imageName: 'ubuntu-16.04'
           rust_target_run: 'x86_64-unknown-linux-musl'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,7 +26,7 @@ jobs:
         rust_target_check: ''
         rust_target_build: ''
         rust_target_run: ''
-        constellation_test_iterations: '20'
+        constellation_test_iterations: '10'
       matrix:
         windows0:
           imageName: 'vs2017-win2016'

--- a/src/bin/constellation/main.rs
+++ b/src/bin/constellation/main.rs
@@ -330,12 +330,20 @@ fn spawn(listen: IpAddr, ip: IpAddr, request: FabricRequest<File, File>) -> (Pid
 	]
 	.iter()
 	.cloned()
-	.chain(request.vars.into_iter().map(|(x, y)| {
-		(
-			CString::new(OsStringExt::into_vec(x)).unwrap(),
-			CString::new(OsStringExt::into_vec(y)).unwrap(),
-		)
-	}))
+	.chain(
+		request
+			.vars
+			.into_iter()
+			.map(|(x, y)| {
+				(
+					CString::new(OsStringExt::into_vec(x)).unwrap(),
+					CString::new(OsStringExt::into_vec(y)).unwrap(),
+				)
+			})
+			.filter(|&(ref x, _)| {
+				x.to_str() != Ok("CONSTELLATION") && x.to_str() != Ok("CONSTELLATION_RESOURCES")
+			}),
+	)
 	.map(|(key, value)| {
 		CString::new(format!(
 			"{}={}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -503,6 +503,7 @@ fn spawn_native(
 				CString::new(OsStringExt::into_vec(y.clone())).unwrap(),
 			)
 		})
+		.filter(|&(ref x, _)| x.to_str() != Ok("CONSTELLATION_RESOURCES"))
 		.chain(iter::once((
 			CString::new("CONSTELLATION_RESOURCES").unwrap(),
 			CString::new(serde_json::to_string(&resources).unwrap()).unwrap(),

--- a/tests/resource-limit-stress.rs
+++ b/tests/resource-limit-stress.rs
@@ -1,0 +1,194 @@
+//= {"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"},{"output":{"1":["",true],"2":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}],"exit":"Success"}
+
+#![allow(clippy::needless_update)]
+
+use constellation::*;
+use rand::{Rng, SeedableRng};
+use rand_pcg::Pcg64Mcg as SmallRng;
+use serde::{Deserialize, Serialize};
+use std::env;
+
+#[derive(Clone, Serialize, Deserialize)]
+struct Node {
+	mem: Mem,
+	cpu: Cpu,
+}
+impl Node {
+	fn fits(&self, process: &Resources) -> bool {
+		process.mem <= self.mem && process.cpu <= self.cpu
+	}
+
+	fn alloc(&mut self, process: &Resources) {
+		assert!(process.cpu <= self.cpu);
+		self.mem -= process.mem;
+		self.cpu -= process.cpu;
+	}
+
+	fn free(&mut self, process: &Resources) {
+		self.mem += process.mem;
+		self.cpu += process.cpu;
+	}
+}
+
+fn main() {
+	let resources = Resources {
+		mem: 20 * Mem::MIB,
+		..Resources::default()
+	};
+	init(resources);
+	let rng = SmallRng::seed_from_u64(0);
+	let round = 0;
+	let mut nodes = vec![
+		Node {
+			mem: 2 * Mem::GIB,
+			cpu: 2 * Cpu::CORE,
+		},
+		Node {
+			mem: Mem::GIB,
+			cpu: Cpu::CORE,
+		},
+		Node {
+			mem: Mem::GIB / 2,
+			cpu: Cpu::CORE / 2,
+		},
+	];
+	nodes[0].alloc(&resources);
+	let processes = vec![Process {
+		node: 0,
+		resources,
+		pid: pid(),
+		sender: None,
+		receiver: None,
+	}];
+	run(rng, round, nodes, processes);
+}
+
+struct Process {
+	node: usize,
+	resources: Resources,
+	pid: Pid,
+	sender: Option<Sender<Pid>>,
+	receiver: Option<Receiver<Pid>>,
+}
+
+fn run(mut rng: SmallRng, round: u64, mut nodes: Vec<Node>, mut processes: Vec<Process>) {
+	let _fabric = env::var("CONSTELLATION") == Ok(String::from("fabric"));
+	for round in round..1000 {
+		let spawner = rng.gen_range(0, processes.len());
+		let spawn_ = rng.gen() || processes.len() == 1;
+		if spawn_ {
+			let resources = Resources {
+				mem: Mem::GIB / 2,
+				cpu: Cpu::CORE / 1000,
+				..Resources::default()
+			};
+			let node = nodes.iter().position(|node| node.fits(&resources));
+			let node = if let Some(node) = node {
+				node
+			} else {
+				// if fabric {
+				// 	try_spawn(
+				// 		Resources {
+				// 			mem: Mem::GIB / 2,
+				// 			cpu: Cpu::CORE / 1000,
+				// 			..Resources::default()
+				// 		},
+				// 		FnOnce!(|_parent| ()),
+				// 	)
+				// 	.block()
+				// 	.err()
+				// 	.expect("spawn() should have failed");
+				// }
+				// TODO: need a barrier
+				continue;
+			};
+			nodes[node].alloc(&resources);
+			if processes[spawner].pid == pid() {
+				let (rng, nodes, processes_) = (
+					rng.clone(),
+					nodes.clone(),
+					processes
+						.iter()
+						.map(
+							|&Process {
+							     node,
+							     resources,
+							     pid,
+							     ..
+							 }| (node, resources, pid),
+						)
+						.collect::<Vec<_>>(),
+				);
+				let spawned_pid = spawn(
+					resources,
+					FnOnce!(move |_parent| {
+						let mut processes = processes_
+							.into_iter()
+							.map(|(node, resources, pid)| Process {
+								node,
+								resources,
+								pid,
+								sender: None,
+								receiver: None,
+							})
+							.collect::<Vec<_>>();
+						processes.push(Process {
+							node,
+							resources: self::resources(),
+							pid: pid(),
+							sender: None,
+							receiver: None,
+						});
+						run(rng, round + 1, nodes, processes);
+					}),
+				)
+				.block()
+				.expect("spawn() failed to allocate process");
+				for &mut Process {
+					pid,
+					ref mut sender,
+					..
+				} in &mut processes
+				{
+					if pid == self::pid() {
+						continue;
+					}
+					*sender = Some(sender.take().unwrap_or_else(|| Sender::new(pid)));
+					sender.as_ref().unwrap().send(spawned_pid).block();
+				}
+				processes.push(Process {
+					node,
+					resources,
+					pid: spawned_pid,
+					sender: None,
+					receiver: None,
+				});
+			} else {
+				let spawner = &mut processes[spawner];
+				let spawner_pid = spawner.pid;
+				let receiver = &mut spawner.receiver;
+				*receiver = Some(
+					receiver
+						.take()
+						.unwrap_or_else(|| Receiver::new(spawner_pid)),
+				);
+				let spawned_pid = receiver.as_ref().unwrap().recv().block().unwrap();
+				processes.push(Process {
+					node,
+					resources,
+					pid: spawned_pid,
+					sender: None,
+					receiver: None,
+				});
+			}
+		} else {
+			if processes[spawner].pid == pid() {
+				return;
+			}
+			let Process {
+				node, resources, ..
+			} = processes.remove(spawner);
+			nodes[node].free(&resources);
+		}
+	}
+}

--- a/tests/resource-limit.rs
+++ b/tests/resource-limit.rs
@@ -1,0 +1,84 @@
+//= {"output":{"2":["",true],"1":["",true]},"children":[{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"},{"output":{"2":["",true],"1":["",true]},"children":[],"exit":"Success"}],"exit":"Success"}
+
+use constellation::*;
+use std::env;
+
+fn main() {
+	init(Resources {
+		mem: 2 * Mem::GIB,
+		..Resources::default()
+	});
+	let fabric = env::var("CONSTELLATION") == Ok(String::from("fabric"));
+	if fabric {
+		try_spawn(
+			Resources {
+				mem: 2 * Mem::GIB,
+				..Resources::default()
+			},
+			FnOnce!(|_parent| ()),
+		)
+		.block()
+		.err()
+		.expect("spawn() should have failed");
+	}
+	for _ in 0..7 {
+		let pid = spawn(
+			Resources {
+				mem: Mem::GIB,
+				..Resources::default()
+			},
+			FnOnce!(|parent| Receiver::<()>::new(parent).recv().block().unwrap()),
+		)
+		.block()
+		.expect("spawn() failed to allocate process");
+		let sender1 = Sender::<()>::new(pid);
+		if fabric {
+			try_spawn(
+				Resources {
+					mem: Mem::GIB,
+					..Resources::default()
+				},
+				FnOnce!(|_parent| ()),
+			)
+			.block()
+			.err()
+			.expect("spawn() should have failed");
+		}
+		for _ in 0..6 {
+			let pid = spawn(
+				Resources {
+					mem: Mem::GIB / 2,
+					..Resources::default()
+				},
+				FnOnce!(|parent| Receiver::<()>::new(parent).recv().block().unwrap()),
+			)
+			.block()
+			.expect("spawn() failed to allocate process");
+			let sender2 = Sender::<()>::new(pid);
+			if fabric {
+				try_spawn(
+					Resources {
+						mem: Mem::GIB / 2,
+						..Resources::default()
+					},
+					FnOnce!(|_parent| ()),
+				)
+				.block()
+				.err()
+				.expect("spawn() should have failed");
+				try_spawn(
+					Resources {
+						mem: Mem::B,
+						..Resources::default()
+					},
+					FnOnce!(|_parent| ()),
+				)
+				.block()
+				.err()
+				.expect("spawn() should have failed");
+			}
+			sender2.send(()).block();
+		}
+		sender1.send(()).block();
+	}
+}

--- a/tests/spawn-send-sleep.rs
+++ b/tests/spawn-send-sleep.rs
@@ -1,0 +1,72 @@
+//= {
+//=   "output": {
+//=     "2": [
+//=       "",
+//=       true
+//=     ],
+//=     "1": [
+//=       "",
+//=       true
+//=     ]
+//=   },
+//=   "children": [
+//=     {
+//=       "output": {
+//=         "2": [
+//=           "",
+//=           true
+//=         ],
+//=         "1": [
+//=           "hi\nho\n",
+//=           true
+//=         ]
+//=       },
+//=       "children": [],
+//=       "exit": "Success"
+//=     },
+//=     {
+//=       "output": {
+//=         "2": [
+//=           "",
+//=           true
+//=         ],
+//=         "1": [
+//=           "hi\nho\n",
+//=           true
+//=         ]
+//=       },
+//=       "children": [],
+//=       "exit": "Success"
+//=     }
+//=   ],
+//=   "exit": "Success"
+//= }
+
+use constellation::*;
+
+fn main() {
+	init(Resources {
+		mem: 20 * Mem::MIB,
+		..Resources::default()
+	});
+	for _ in 0..2 {
+		let pid = spawn(
+			Resources {
+				mem: 20 * Mem::MIB,
+				..Resources::default()
+			},
+			FnOnce!(|parent| {
+				let receiver = Receiver::<String>::new(parent);
+				println!("{}", receiver.recv().block().unwrap());
+				std::thread::sleep(std::time::Duration::from_millis(1000));
+				println!("{}", receiver.recv().block().unwrap());
+			}),
+		)
+		.block()
+		.expect("spawn() failed");
+		let sender = Sender::<String>::new(pid);
+		sender.send(String::from("hi")).block();
+		std::thread::sleep(std::time::Duration::from_millis(100));
+		sender.send(String::from("ho")).block();
+	}
+}

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -29,11 +29,11 @@ use multiset::HashMultiSet;
 use palaver::file::FdIter;
 use serde::{Deserialize, Serialize};
 use std::{
-	collections::HashMap, env, ffi::OsStr, fmt, fmt::Debug, fs::{self, File}, hash, io::{self, BufRead, BufReader}, iter, mem, net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream}, path::{Path, PathBuf}, process, str, thread, thread::JoinHandle, time::{self, Duration}
+	collections::HashMap, env, ffi::OsStr, fmt, fmt::Debug, fs::{self, File}, hash, io::{self, BufRead, BufReader}, iter, mem, net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream}, path::{Path, PathBuf}, process, str, sync::mpsc, thread, thread::JoinHandle, time::{self, Duration}
 };
 use systemstat::{saturating_sub_bytes, Platform, System};
 
-use constellation_internal::{abort_on_unwind, Cpu, ExitStatus, Fd, Mem};
+use constellation_internal::{abort_on_unwind, Cpu, ExitStatus, FabricOutputEvent, Fd, Mem};
 use ext::serialize_as_regex_string::SerializeAsRegexString;
 
 const DEPLOY: &str = "src/bin/deploy.rs";
@@ -248,9 +248,14 @@ fn main() {
 	let iterations: usize = env::var("CONSTELLATION_TEST_ITERATIONS")
 		.map(|x| x.parse().unwrap())
 		.unwrap_or(1);
+	let test = env::var("CONSTELLATION_TEST").ok();
 	let tests = fs::read_dir(TESTS).unwrap().filter_map(|path| {
 		let path = path.ok()?.path();
-		if path.extension()? == "rs" {
+		let is_test = path.extension()? == "rs"
+			&& test.as_ref().map_or(true, |test| {
+				Some(&**test) == path.file_stem().unwrap().to_str()
+			});
+		if is_test {
 			Some(String::from(path.file_stem()?.to_str()?))
 		} else {
 			None
@@ -389,7 +394,7 @@ fn main() {
 			println!("{}", src.display());
 			for i in 0..iterations {
 				println!("    {}", i);
-				let result = environment.run(bin);
+				let result = environment.run(bin, file.as_ref().ok());
 				let output = parse_output(&result);
 				if output.is_err()
 					|| file.is_err() || !file.as_ref().unwrap().is_match(output.as_ref().unwrap())
@@ -426,14 +431,14 @@ fn main() {
 
 trait Environment: Debug {
 	fn start(&mut self) {}
-	fn run(&mut self, bin: &Path) -> process::Output;
+	fn run(&mut self, bin: &Path, output: Option<&OutputTest>) -> process::Output;
 	fn stop(&mut self) {}
 }
 
 #[derive(Debug)]
 struct Native;
 impl Environment for Native {
-	fn run(&mut self, bin: &Path) -> process::Output {
+	fn run(&mut self, bin: &Path, _output: Option<&OutputTest>) -> process::Output {
 		process::Command::new(bin)
 			.env_remove("CONSTELLATION_VERSION")
 			.env("CONSTELLATION_FORMAT", "json")
@@ -449,6 +454,7 @@ enum Cluster {
 	Running {
 		config: ClusterConfig,
 		cluster: Vec<ClusterNode>,
+		stdout: mpsc::Receiver<(usize, Option<Result<FabricOutputEvent, serde_json::Error>>)>,
 	},
 	Invalid,
 }
@@ -479,11 +485,15 @@ impl Socket {
 		}
 	}
 }
-#[derive(Debug)]
 struct ClusterNode {
 	process: process::Child,
-	stdout: JoinHandle<bool>,
+	stdout: JoinHandle<()>,
 	stderr: JoinHandle<bool>,
+}
+impl Debug for ClusterNode {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		f.debug_struct("ClusterNode").finish()
+	}
 }
 
 impl Cluster {
@@ -502,6 +512,7 @@ impl Environment for Cluster {
 		} else {
 			panic!()
 		};
+		let (sender, receiver) = mpsc::sync_channel(0);
 		let mut cluster = config
 			.nodes
 			.iter()
@@ -546,10 +557,15 @@ impl Environment for Cluster {
 					.spawn()
 					.unwrap();
 				let stdout = process.stdout.take().unwrap();
-				let stdout = capture_stdout(stdout, true, move |none, output| {
-					*none = false;
-					println!("fab stdout: {:?}", str::from_utf8(output).unwrap());
-				});
+				let sender = sender.clone();
+				let stdout = thread::spawn(abort_on_unwind(move || {
+					for msg in
+						serde_json::StreamDeserializer::new(serde_json::de::IoRead::new(stdout))
+					{
+						sender.send((i, Some(msg))).unwrap();
+					}
+					sender.send((i, None)).unwrap();
+				}));
 				let stderr = process.stderr.take().unwrap();
 				let stderr = capture_stdout(stderr, true, move |none, output| {
 					*none = false;
@@ -564,6 +580,8 @@ impl Environment for Cluster {
 					thread::sleep(std::time::Duration::new(0, 1_000_000));
 				}
 				if let Some(bridge) = node.bridge {
+					let _bridge_pid: FabricOutputEvent =
+						receiver.recv().unwrap().1.unwrap().unwrap();
 					while TcpStream::connect(bridge.external).is_err() {
 						// TODO: parse output rather than this loop and timeout
 						if start_.elapsed() > time::Duration::new(15, 0) {
@@ -580,33 +598,74 @@ impl Environment for Cluster {
 			})
 			.collect::<Vec<_>>();
 		cluster.reverse();
-		*self = Cluster::Running { config, cluster }
+		*self = Cluster::Running {
+			config,
+			cluster,
+			stdout: receiver,
+		}
 	}
-	fn run(&mut self, bin: &Path) -> process::Output {
-		let config = if let Self::Running { config, .. } = self {
-			config
+	fn run(&mut self, bin: &Path, output: Option<&OutputTest>) -> process::Output {
+		let (config, stdout) = if let Self::Running { config, stdout, .. } = self {
+			(config, stdout)
 		} else {
 			panic!()
 		};
-		process::Command::new(&config.deploy)
-			.env_remove("CONSTELLATION_VERSION")
-			.env_remove("CONSTELLATION_FORMAT")
-			.args(&[
-				"--format=json",
-				&config.nodes[0].bridge.unwrap().external.to_string(),
-				bin.to_str().unwrap(),
-			])
-			.output()
-			.unwrap()
+		crossbeam::thread::scope(|scope| {
+			if let Some(output) = output {
+				fn count_processes(output_test: &OutputTest) -> usize {
+					1 + output_test
+						.children
+						.iter()
+						.map(count_processes)
+						.sum::<usize>()
+				}
+				let processes = count_processes(output);
+				let _ = scope.spawn(move |_| {
+					let mut pids = HashMap::new();
+					for _ in 0..processes * 2 {
+						let (_node, msg) = stdout.recv().unwrap();
+						match msg.unwrap().unwrap() {
+							FabricOutputEvent::Init { pid, system_pid } => {
+								let x = pids.insert(pid, system_pid);
+								assert!(x.is_none());
+							}
+							FabricOutputEvent::Exit { pid, system_pid } => {
+								let x = pids.remove(&pid);
+								assert_eq!(x, Some(system_pid));
+							}
+						}
+					}
+					assert!(pids.is_empty(), "{:?}", pids);
+					if let Ok(err) = stdout.try_recv() {
+						panic!("{:?}", err);
+					}
+				});
+			}
+			process::Command::new(&config.deploy)
+				.env_remove("CONSTELLATION_VERSION")
+				.env_remove("CONSTELLATION_FORMAT")
+				.args(&[
+					"--format=json",
+					&config.nodes[0].bridge.unwrap().external.to_string(),
+					bin.to_str().unwrap(),
+				])
+				.output()
+				.unwrap()
+		})
+		.unwrap()
 	}
 	fn stop(&mut self) {
-		let (config, cluster) =
-			if let Self::Running { config, cluster } = mem::replace(self, Self::Invalid) {
-				(config, cluster)
-			} else {
-				panic!()
-			};
-		for mut node in cluster {
+		let (config, cluster, stdout) = if let Self::Running {
+			config,
+			cluster,
+			stdout,
+		} = mem::replace(self, Self::Invalid)
+		{
+			(config, cluster, stdout)
+		} else {
+			panic!()
+		};
+		for (i, mut node) in cluster.into_iter().enumerate() {
 			println!("killing");
 			node.process.kill().unwrap();
 			println!("waiting");
@@ -615,8 +674,11 @@ impl Environment for Cluster {
 			let stderr_empty = node.stderr.join().unwrap();
 			assert!(stderr_empty);
 			println!("waiting stdout");
-			let _stdout_empty = node.stdout.join().unwrap();
-			// assert!(stdout_empty);
+			let x = stdout.recv().unwrap();
+			assert_eq!(x.0, i);
+			assert!(x.1.is_none());
+			println!("waiting stdout thread");
+			node.stdout.join().unwrap();
 		}
 		*self = Self::Init(config);
 	}

--- a/tests/tester/main.rs
+++ b/tests/tester/main.rs
@@ -633,7 +633,7 @@ fn capture_stdout<
 	}))
 }
 
-fn json_to_string<T: ?Sized>(value: &T) -> Result<String>
+fn json_to_string<T: ?Sized>(value: &T) -> Result<String, serde_json::Error>
 where
 	T: Serialize,
 {
@@ -643,7 +643,7 @@ where
 			return Ok(pretty);
 		}
 	}
-	dense
+	Ok(dense)
 }
 
 struct SystemLoad {


### PR DESCRIPTION
This adds a very strong test, `resource-limit-stress`, which concurrently spawns and drops 471 communicating processes. It takes ages, so the CI test iterations have been reduced. I've doubled the number of linux CI runners however.

Also add parsing of fabric output to the test harness; this catches a very rare (~1 every 5 cpu hours running the `output-data` test in a tight loop) hang, see pid 109965 not exiting here:
```
2020-02-11T19:53:52.9035098Z Memory: 781.1 MB used / 7.3 GB (7284568064 bytes) total (PlatformMemory { meminfo: {"Active": 3.4 GB, "Active(anon)": 415.6 MB, "Active(file)": 2.9 GB, "AnonHugePages": 245.4 MB, "AnonPages": 447.5 MB, "Bounce": 0 B, "Buffers": 162.2 MB, "Cached": 5.5 GB, "CmaFree": 0 B, "CmaTotal": 0 B, "CommitLimit": 12.2 GB, "Committed_AS": 2.8 GB, "DirectMap1G": 6.4 GB, "DirectMap2M": 3.1 GB, "DirectMap4k": 127.9 MB, "Dirty": 41.0 KB, "HardwareCorrupted": 0 B, "Hugepagesize": 2.1 MB, "Inactive": 2.8 GB, "Inactive(anon)": 102.1 MB, "Inactive(file)": 2.7 GB, "KernelStack": 6.8 MB, "Mapped": 254.5 MB, "MemAvailable": 6.2 GB, "MemFree": 636.5 MB, "MemTotal": 7.3 GB, "Mlocked": 3.8 MB, "NFS_Unstable": 0 B, "PageTables": 8.1 MB, "SReclaimable": 226.2 MB, "SUnreclaim": 77.2 MB, "Shmem": 69.7 MB, "ShmemHugePages": 0 B, "ShmemPmdMapped": 0 B, "Slab": 303.3 MB, "SwapCached": 8.2 KB, "SwapFree": 8.6 GB, "SwapTotal": 8.6 GB, "Unevictable": 3.8 MB, "VmallocChunk": 0 B, "VmallocTotal": 35.2 TB, "VmallocUsed": 0 B, "Writeback": 0 B, "WritebackTmp": 0 B} })
2020-02-11T19:53:52.9036163Z Load average: 2.3427734 3.8081055 3.6811523
2020-02-11T19:53:52.9036359Z CPU load: 0% user, 0% nice, 0% system, 0% intr, 100% idle
2020-02-11T19:53:52.9036531Z Processes: 131, threads: 284
2020-02-11T19:53:52.9036672Z File descriptors: 1472 open, 706991 max
2020-02-11T19:53:52.9037421Z tests/output-data.rs
2020-02-11T19:53:52.9037616Z     0
2020-02-11T19:53:53.0454193Z fab stdout: "{\"init\":{\"pid\":{\"key\":274773370605286673489937816620515070915,\"ip\":\"127.0.0.1\",\"port\":42413},\"system_pid\":109892}}\n"
2020-02-11T19:53:53.0578561Z fab stdout: "{\"exit\":{\"pid\":{\"key\":274773370605286673489937816620515070915,\"ip\":\"127.0.0.1\",\"port\":42413},\"system_pid\":109892}}\n"
2020-02-11T19:53:53.0962008Z     1
2020-02-11T19:53:53.2338325Z fab stdout: "{\"init\":{\"pid\":{\"key\":198082233292506167084671543068278489464,\"ip\":\"127.0.0.1\",\"port\":34983},\"system_pid\":109916}}\n"
2020-02-11T19:53:53.2447520Z fab stdout: "{\"exit\":{\"pid\":{\"key\":198082233292506167084671543068278489464,\"ip\":\"127.0.0.1\",\"port\":34983},\"system_pid\":109916}}\n"
2020-02-11T19:53:53.2840786Z     2
2020-02-11T19:53:53.4194760Z fab stdout: "{\"init\":{\"pid\":{\"key\":26910306650878490903501923730859136574,\"ip\":\"127.0.0.1\",\"port\":36845},\"system_pid\":109940}}\n"
2020-02-11T19:53:53.4322153Z fab stdout: "{\"exit\":{\"pid\":{\"key\":26910306650878490903501923730859136574,\"ip\":\"127.0.0.1\",\"port\":36845},\"system_pid\":109940}}\n"
2020-02-11T19:53:53.4721202Z     3
2020-02-11T19:53:53.6167364Z fab stdout: "{\"init\":{\"pid\":{\"key\":1612076484495532056923727983250612711,\"ip\":\"127.0.0.1\",\"port\":34465},\"system_pid\":109965}}\n"
2020-02-11T19:53:53.6640465Z     4
2020-02-11T19:53:53.8037926Z fab stdout: "{\"init\":{\"pid\":{\"key\":293338737214668155455319182865647767841,\"ip\":\"127.0.0.1\",\"port\":43981},\"system_pid\":109993}}\n"
2020-02-11T19:53:53.8145987Z fab stdout: "{\"exit\":{\"pid\":{\"key\":293338737214668155455319182865647767841,\"ip\":\"127.0.0.1\",\"port\":43981},\"system_pid\":109993}}\n"
2020-02-11T19:53:53.8600468Z     5
2020-02-11T19:53:54.0017557Z fab stdout: "{\"init\":{\"pid\":{\"key\":15118717843972193183638946127534517648,\"ip\":\"127.0.0.1\",\"port\":32769},\"system_pid\":110017}}\n"
2020-02-11T19:53:54.0156548Z fab stdout: "{\"exit\":{\"pid\":{\"key\":15118717843972193183638946127534517648,\"ip\":\"127.0.0.1\",\"port\":32769},\"system_pid\":110017}}\n"
2020-02-11T19:53:54.0554074Z     6
2020-02-11T19:53:54.2055258Z fab stdout: "{\"init\":{\"pid\":{\"key\":289869825600804344587524749851988246995,\"ip\":\"127.0.0.1\",\"port\":46361},\"system_pid\":110042}}\n"
2020-02-11T19:53:54.2166899Z fab stdout: "{\"exit\":{\"pid\":{\"key\":289869825600804344587524749851988246995,\"ip\":\"127.0.0.1\",\"port\":46361},\"system_pid\":110042}}\n"
2020-02-11T19:53:54.2561509Z     7
2020-02-11T19:53:54.3960407Z fab stdout: "{\"init\":{\"pid\":{\"key\":202314181534811222481601923695096653730,\"ip\":\"127.0.0.1\",\"port\":41803},\"system_pid\":110066}}\n"
2020-02-11T19:53:54.4080228Z fab stdout: "{\"exit\":{\"pid\":{\"key\":202314181534811222481601923695096653730,\"ip\":\"127.0.0.1\",\"port\":41803},\"system_pid\":110066}}\n"
2020-02-11T19:53:54.4442655Z     8
2020-02-11T19:53:54.5896521Z fab stdout: "{\"init\":{\"pid\":{\"key\":287275833841488667447350661600443489574,\"ip\":\"127.0.0.1\",\"port\":38497},\"system_pid\":110091}}\n"
2020-02-11T19:53:54.6029687Z fab stdout: "{\"exit\":{\"pid\":{\"key\":287275833841488667447350661600443489574,\"ip\":\"127.0.0.1\",\"port\":38497},\"system_pid\":110091}}\n"
2020-02-11T19:53:54.6440777Z     9
2020-02-11T19:53:54.7799018Z fab stdout: "{\"init\":{\"pid\":{\"key\":54734315715571197327329834059527787409,\"ip\":\"127.0.0.1\",\"port\":43535},\"system_pid\":110115}}\n"
2020-02-11T19:53:54.7911026Z fab stdout: "{\"exit\":{\"pid\":{\"key\":54734315715571197327329834059527787409,\"ip\":\"127.0.0.1\",\"port\":43535},\"system_pid\":110115}}\n"
2020-02-11T19:53:55.3581124Z Memory: 817.6 MB used / 7.3 GB (7284568064 bytes) total (PlatformMemory { meminfo: {"Active": 3.4 GB, "Active(anon)": 433.5 MB, "Active(file)": 3.0 GB, "AnonHugePages": 245.4 MB, "AnonPages": 449.6 MB, "Bounce": 0 B, "Buffers": 162.2 MB, "Cached": 5.6 GB, "CmaFree": 0 B, "CmaTotal": 0 B, "CommitLimit": 12.2 GB, "Committed_AS": 3.0 GB, "DirectMap1G": 6.4 GB, "DirectMap2M": 3.1 GB, "DirectMap4k": 127.9 MB, "Dirty": 53.2 KB, "HardwareCorrupted": 0 B, "Hugepagesize": 2.1 MB, "Inactive": 2.8 GB, "Inactive(anon)": 119.9 MB, "Inactive(file)": 2.7 GB, "KernelStack": 7.1 MB, "Mapped": 257.7 MB, "MemAvailable": 6.2 GB, "MemFree": 600.0 MB, "MemTotal": 7.3 GB, "Mlocked": 3.8 MB, "NFS_Unstable": 0 B, "PageTables": 8.7 MB, "SReclaimable": 226.2 MB, "SUnreclaim": 76.9 MB, "Shmem": 103.0 MB, "ShmemHugePages": 0 B, "ShmemPmdMapped": 0 B, "Slab": 303.1 MB, "SwapCached": 8.2 KB, "SwapFree": 8.6 GB, "SwapTotal": 8.6 GB, "Unevictable": 3.8 MB, "VmallocChunk": 0 B, "VmallocTotal": 35.2 TB, "VmallocUsed": 0 B, "Writeback": 0 B, "WritebackTmp": 0 B} })
2020-02-11T19:53:55.3583021Z Load average: 2.3427734 3.8081055 3.6811523
2020-02-11T19:53:55.3583653Z CPU load: 0% user, 0% nice, 0.9803922% system, 0% intr, 99.01961% idle
2020-02-11T19:53:55.3584105Z Processes: 143, threads: 308
2020-02-11T19:53:55.3584327Z File descriptors: 1504 open, 706991 max
```